### PR TITLE
Add support for indexing content from globals

### DIFF
--- a/src/Elasticraft.php
+++ b/src/Elasticraft.php
@@ -135,6 +135,11 @@ class Elasticraft extends Plugin
                     $doc = ElasticDocument::withEntry( $event->element );
                     return $this->elasticraftService->indexDocument($doc);
                 }
+
+                if ( $event->element instanceof craft\elements\GlobalSet ) {
+                    $doc = ElasticDocument::withGlobalSet( $event->element );
+                    return $this->elasticraftService->indexDocument($doc);
+                }
             }
         );
 
@@ -158,8 +163,8 @@ class Elasticraft extends Plugin
                 if ( $event->element instanceof craft\elements\Entry ) {
                     // Not working: $doc = ElasticDocument::withEntry( $event->element );
                     // Fetch entry again to get URI:
-                    $doc = ElasticDocument::withEntry( 
-                        Entry::find()->id( $event->element->id )->one() 
+                    $doc = ElasticDocument::withEntry(
+                        Entry::find()->id( $event->element->id )->one()
                     );
                     return $this->elasticraftService->indexDocument($doc);
                 }

--- a/src/models/ElasticDocument.php
+++ b/src/models/ElasticDocument.php
@@ -43,11 +43,11 @@ class ElasticDocument extends Model
     public $body = [];
     public $dateCreated;
     public $dateUpdated;
-    // parent children relationships requires different document types in Elasticsearch for now. 
+    // parent children relationships requires different document types in Elasticsearch for now.
     //public $parent;
     //public $routing;
 
-    protected $transformers = []; 
+    protected $transformers = [];
 
     public function init()
     {
@@ -68,6 +68,13 @@ class ElasticDocument extends Model
         return $instance;
     }
 
+    public static function withGlobalSet( craft\elements\GlobalSet $globalSet )
+    {
+        $instance = new self();
+        $instance->loadByGlobalSet( $globalSet );
+        return $instance;
+    }
+
     protected function loadByEntry( craft\elements\Entry $entry )
     {
         $this->type = $entry->section->handle;
@@ -77,6 +84,18 @@ class ElasticDocument extends Model
         }
         $this->body['elastic']['dateCreated'] = $entry->dateCreated->format('U');
         $this->body['elastic']['dateUpdated'] = $entry->dateUpdated->format('U');
+        $this->body['elastic']['dateIndexed'] = time();
+    }
+
+    protected function loadByGlobalSet( craft\elements\GlobalSet $globalSet )
+    {
+        $this->type = 'global';
+        $this->id = $globalSet->handle;
+        if ( isset( $this->transformers[$this->type] ) ) {
+            $this->body = $this->transformers[$this->type]->transform($globalSet);
+        }
+        $this->body['elastic']['dateCreated'] = $globalSet->dateCreated->format('U');
+        $this->body['elastic']['dateUpdated'] = $globalSet->dateUpdated->format('U');
         $this->body['elastic']['dateIndexed'] = time();
     }
 

--- a/src/models/ElasticDocument.php
+++ b/src/models/ElasticDocument.php
@@ -89,11 +89,14 @@ class ElasticDocument extends Model
 
     protected function loadByGlobalSet( craft\elements\GlobalSet $globalSet )
     {
-        $this->type = 'global';
+        // We'll prefix the type in order to avoid conflict with channels/structures
+        $this->type = 'global:' . $globalSet->handle;
         $this->id = $globalSet->handle;
+
         if ( isset( $this->transformers[$this->type] ) ) {
             $this->body = $this->transformers[$this->type]->transform($globalSet);
         }
+
         $this->body['elastic']['dateCreated'] = $globalSet->dateCreated->format('U');
         $this->body['elastic']['dateUpdated'] = $globalSet->dateUpdated->format('U');
         $this->body['elastic']['dateIndexed'] = time();

--- a/src/models/ElasticDocument.php
+++ b/src/models/ElasticDocument.php
@@ -90,7 +90,7 @@ class ElasticDocument extends Model
     protected function loadByGlobalSet( craft\elements\GlobalSet $globalSet )
     {
         // We'll prefix the type in order to avoid conflict with channels/structures
-        $this->type = 'global:' . $globalSet->handle;
+        $this->type = 'global-' . $globalSet->handle;
         $this->id = $globalSet->handle;
 
         if ( isset( $this->transformers[$this->type] ) ) {


### PR DESCRIPTION
Currently only entries is indexed through elasticraft. This PR adds support for indexing GlobalSets as well - the type of element being used when saving data to globals in craft.

Since the GlobalSet entries has no ids (there's no need for one as there is only one record per globalset), I've used the type `global` and the handle is used as id.

Example:
- the global set with handle _emergency_ will be transformed using the transformer set up for `global` in `config/elasticraft.php`
- the object stored to elastic will have the type: `global` and id: `emergency`